### PR TITLE
Initialise couplings to zero

### DIFF
--- a/simulated_annealing-Solution.ipynb
+++ b/simulated_annealing-Solution.ipynb
@@ -46,6 +46,7 @@
     "    weights = data[:,3]\n",
     "    num_spin = max(maximum(is), maximum(js))\n",
     "    J = similar(weights, num_spin, num_spin)\n",
+    "    fill!(J, 0.0)\n",
     "    @inbounds for (i, j, weight) = zip(is, js, weights)\n",
     "        J[i,j] = weight/2\n",
     "        J[j,i] = weight/2\n",

--- a/simulated_annealing.ipynb
+++ b/simulated_annealing.ipynb
@@ -46,6 +46,7 @@
     "    weights = data[:,3]\n",
     "    num_spin = max(maximum(is), maximum(js))\n",
     "    J = similar(weights, num_spin, num_spin)\n",
+    "    fill!(J, 0.0)\n",
     "    @inbounds for (i, j, weight) = zip(is, js, weights)\n",
     "        J[i,j] = weight/2\n",
     "        J[j,i] = weight/2\n",


### PR DESCRIPTION
In the simulated_annealing notebooks the array for couplings is created using the similar function. This creates an array of uninitialised values, not all over which are overwritten with values from the couplings file. This results in NaNs and also failing tests. Explicitly filling the couplings array with zeros avoids this. 